### PR TITLE
feat: open selected tasks in the web browser

### DIFF
--- a/ui/components/table-tasks/taskstable.go
+++ b/ui/components/table-tasks/taskstable.go
@@ -20,7 +20,6 @@ type Model struct {
 	ctx               *context.UserContext
 	ComponentId       common.ComponentId
 	columns           []table.Column
-	requiredCols      []table.Column
 	table             table.Model
 	size              common.Size
 	SelectedTaskIndex int
@@ -109,9 +108,7 @@ func (m Model) KeyMap() help.KeyMap {
 }
 
 func InitialModel(ctx *context.UserContext, logger *log.Logger) Model {
-	columns := []table.Column{}
-
-	requiredCols := []table.Column{
+	columns := []table.Column{
 		table.NewFlexColumn("name", "Name", 70),
 		table.NewFlexColumn("status", "Status", 5).
 			WithStyle(
@@ -123,8 +120,6 @@ func InitialModel(ctx *context.UserContext, logger *log.Logger) Model {
 		Width:  0,
 		Height: 0,
 	}
-
-	columns = append(columns, requiredCols...)
 
 	tableKeyMap := table.DefaultKeyMap()
 	tableKeyMap.RowSelectToggle = key.NewBinding(
@@ -154,7 +149,6 @@ func InitialModel(ctx *context.UserContext, logger *log.Logger) Model {
 		ctx:          ctx,
 		table:        t,
 		columns:      columns,
-		requiredCols: requiredCols,
 		tasks:        []clickup.Task{},
 		autoColumns:  false,
 		size:         size,
@@ -247,9 +241,6 @@ func (m Model) TabChanged(tabId string) (Model, tea.Cmd) {
 
 	m.log.Infof("Received TabChangedMsg: %s", tabId)
 
-	columns := []table.Column{}
-	columns = append(columns, m.requiredCols...)
-
 	// if m.autoColumns {
 	//      tab := viewtabs.Tab(msg)
 	// 	for _, field := range view.Columns.Fields {
@@ -262,9 +253,6 @@ func (m Model) TabChanged(tabId string) (Model, tea.Cmd) {
 	// 		})
 	// 	}
 	// }
-
-	m.log.Infof("Columns: %d", len(columns))
-	m.setColumns(columns)
 	m.SetTasks(m.tasks)
 
 	if len(m.tasks) != 0 { // TODO: store tasks list in var

--- a/ui/components/table-tasks/taskstable.go
+++ b/ui/components/table-tasks/taskstable.go
@@ -19,7 +19,6 @@ type Model struct {
 	log               *log.Logger
 	ctx               *context.UserContext
 	ComponentId       common.ComponentId
-	requiredColsKeys  []string
 	columns           []table.Column
 	requiredCols      []table.Column
 	table             table.Model
@@ -119,7 +118,6 @@ func InitialModel(ctx *context.UserContext, logger *log.Logger) Model {
 				lipgloss.NewStyle().Align(lipgloss.Center),
 			),
 	}
-	requiredColsKeys := []string{"name", "status"}
 
 	size := common.Size{
 		Width:  0,
@@ -152,19 +150,18 @@ func InitialModel(ctx *context.UserContext, logger *log.Logger) Model {
 	log := logger.WithPrefix(logger.GetPrefix() + "/" + ComponentId)
 
 	return Model{
-		ComponentId:      ComponentId,
-		ctx:              ctx,
-		table:            t,
-		columns:          columns,
-		requiredCols:     requiredCols,
-		requiredColsKeys: requiredColsKeys,
-		tasks:            []clickup.Task{},
-		autoColumns:      false,
-		size:             size,
-		Focused:          false,
-		Hidden:           false,
-		log:              log,
-		ifBorders:        true,
+		ComponentId:  ComponentId,
+		ctx:          ctx,
+		table:        t,
+		columns:      columns,
+		requiredCols: requiredCols,
+		tasks:        []clickup.Task{},
+		autoColumns:  false,
+		size:         size,
+		Focused:      false,
+		Hidden:       false,
+		log:          log,
+		ifBorders:    true,
 	}
 }
 

--- a/ui/components/table-tasks/taskstable.go
+++ b/ui/components/table-tasks/taskstable.go
@@ -23,7 +23,6 @@ type Model struct {
 	table             table.Model
 	size              common.Size
 	SelectedTaskIndex int
-	autoColumns       bool
 	Focused           bool
 	Hidden            bool
 	ifBorders         bool
@@ -145,17 +144,16 @@ func InitialModel(ctx *context.UserContext, logger *log.Logger) Model {
 	log := logger.WithPrefix(logger.GetPrefix() + "/" + ComponentId)
 
 	return Model{
-		ComponentId:  ComponentId,
-		ctx:          ctx,
-		table:        t,
-		columns:      columns,
-		tasks:        []clickup.Task{},
-		autoColumns:  false,
-		size:         size,
-		Focused:      false,
-		Hidden:       false,
-		log:          log,
-		ifBorders:    true,
+		ComponentId: ComponentId,
+		ctx:         ctx,
+		table:       t,
+		columns:     columns,
+		tasks:       []clickup.Task{},
+		size:        size,
+		Focused:     false,
+		Hidden:      false,
+		log:         log,
+		ifBorders:   true,
 	}
 }
 
@@ -241,18 +239,6 @@ func (m Model) TabChanged(tabId string) (Model, tea.Cmd) {
 
 	m.log.Infof("Received TabChangedMsg: %s", tabId)
 
-	// if m.autoColumns {
-	//      tab := viewtabs.Tab(msg)
-	// 	for _, field := range view.Columns.Fields {
-	// 		if field.Field == "name" || field.Field == "status" { // TODO: check if in requiredCols
-	// 			continue
-	// 		}
-	// 		columns = append(columns, table.Column{
-	// 			Title: field.Field,
-	// 			Width: 30,
-	// 		})
-	// 	}
-	// }
 	m.SetTasks(m.tasks)
 
 	if len(m.tasks) != 0 { // TODO: store tasks list in var

--- a/ui/components/table-tasks/taskstable.go
+++ b/ui/components/table-tasks/taskstable.go
@@ -251,12 +251,6 @@ func (m Model) TabChanged(tabId string) (Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
-func (m *Model) setColumns(columns []table.Column) {
-	m.columns = columns
-	m.table = m.table.
-		WithColumns(m.columns)
-}
-
 func (m *Model) SetTasks(tasks []clickup.Task) {
 	m.tasks = tasks
 	items := taskListToRows(tasks, m.GetColumnsKey())

--- a/ui/components/table-tasks/utils.go
+++ b/ui/components/table-tasks/utils.go
@@ -21,6 +21,40 @@ func taskToRow(task clickup.Task, columns []string) table.Row {
 			values[column] = task.Status.Status
 		case "name":
 			values[column] = task.Name
+		case "url":
+			values[column] = task.Url
+			// After migration from charm to evertras/bubble-table I temporary removed all columns
+			// except "status" and "name" since they are not supported yet. See autoColumns feature
+			// case "assignee":
+			// 	values = append(values, task.GetAssignees())
+			// case "list":
+			// 	values = append(values, task.List.String())
+			// case "tags":
+			// 	values = append(values, task.GetTags())
+			// case "folder":
+			// 	values = append(values, task.Folder.String())
+			// case "space":
+			// 	values = append(values, task.Space.Id)
+			// case "id":
+			// 	values = append(values, task.Id)
+		}
+	}
+
+	return table.NewRow(table.RowData(values))
+}
+
+func rowToTask(row table.Row, columns []string) clickup.Task {
+	var task clickup.Task
+	data := row.Data
+
+	for _, column := range columns {
+		switch column {
+		case "status":
+			task.Status.Status = data[column].(string)
+		case "name":
+			task.Name = data[column].(string)
+		case "url":
+			task.Url = data[column].(string)
 			// After migration from charm to evertras/bubble-table I temporary removed all columns
 			// except "status" and "name" since they are not supported yet. See autoColumns feature
 			// case "assignee":
@@ -40,5 +74,5 @@ func taskToRow(task clickup.Task, columns []string) table.Row {
 		}
 	}
 
-	return table.NewRow(table.RowData(values))
+	return task
 }

--- a/ui/widgets/tasks/tasks.go
+++ b/ui/widgets/tasks/tasks.go
@@ -73,12 +73,17 @@ func InitialModel(ctx *context.UserContext, logger *log.Logger) Model {
 }
 
 type KeyMap struct {
-	OpenTicketInWebBrowser key.Binding
-	ToggleSidebar          key.Binding
+	OpenTicketInWebBrowserBatch key.Binding
+	OpenTicketInWebBrowser      key.Binding
+	ToggleSidebar               key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
 	return KeyMap{
+		OpenTicketInWebBrowserBatch: key.NewBinding(
+			key.WithKeys("U"),
+			key.WithHelp("U", "batch open in web browser"),
+		),
 		OpenTicketInWebBrowser: key.NewBinding(
 			key.WithKeys("u"),
 			key.WithHelp("u", "open in web browser"),
@@ -131,11 +136,22 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch {
+		case key.Matches(msg, m.keyMap.OpenTicketInWebBrowserBatch):
+			tasks := m.componenetTasksTable.GetSelectedTasks()
+			for _, task := range tasks {
+				m.log.Debug("Opening task in the web browser", "url", task.Url)
+				if err := common.OpenUrlInWebBrowser(task.Url); err != nil {
+					m.log.Fatal(err)
+				}
+			}
+
 		case key.Matches(msg, m.keyMap.OpenTicketInWebBrowser):
 			task := m.componenetTasksTable.GetHighlightedTask()
+			m.log.Debug("Opening task in the web browser", "url", task.Url)
 			if err := common.OpenUrlInWebBrowser(task.Url); err != nil {
 				m.log.Fatal(err)
 			}
+
 		case key.Matches(msg, m.keyMap.ToggleSidebar):
 			m.componenetTasksSidebar = m.componenetTasksSidebar.SetHidden(!m.componenetTasksSidebar.GetHidden())
 		}


### PR DESCRIPTION
# Summary

From a long time, the table task has been supporting multiple selection of rows. Until this PR, it was never used. From today, you can select multiple tasks with "space" (or other binding) and all of them open in your default web browser

## Changes:

- chore: remove unused tabletasks.requiredColsKeys field
- chore: remove requiredCols and rely only on columns prop
- chore: remove autoColumns prop
- chore: remove unused setColumns
- feat: open selected tasks in the web browser
