### PR TITLE
chore: create generic clickup/Client.get method

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"log/slog"
+	"slices"
 
 	"github.com/charmbracelet/log"
 
@@ -61,7 +62,7 @@ func (m *Api) GetSpaces(teamId string) ([]clickup.Space, error) {
 	client := m.Clickup
 
 	m.logger.Debugf("Fetching spaces from API")
-	spaces, err := client.GetSpaces(teamId)
+	spaces, err := client.GetSpacesFromTeam(teamId)
 	if err != nil {
 		return nil, err
 	}
@@ -272,6 +273,7 @@ func (m *Api) GetViewsFromFolder(folderId string) ([]clickup.View, error) {
 	if err != nil {
 		return nil, err
 	}
+	views = filterViews(views, []clickup.ViewType{clickup.ViewTypeList})
 	m.logger.Debugf("Found %d views in folder %s", len(views), folderId)
 
 	m.Cache.Set(cacheNamespace, folderId, views)
@@ -301,6 +303,7 @@ func (m *Api) GetViewsFromList(listId string) ([]clickup.View, error) {
 	if err != nil {
 		return nil, err
 	}
+	views = filterViews(views, []clickup.ViewType{clickup.ViewTypeList})
 	m.logger.Debugf("Found %d views in folder %s", len(views), listId)
 
 	m.Cache.Set(cacheNamespace, listId, views)
@@ -331,6 +334,7 @@ func (m *Api) GetViewsFromSpace(spaceId string) ([]clickup.View, error) {
 	if err != nil {
 		return nil, err
 	}
+	views = filterViews(views, []clickup.ViewType{clickup.ViewTypeList})
 	m.logger.Debugf("Found %d views in space %s", len(views), spaceId)
 
 	m.Cache.Set(cacheNamespace, spaceId, views)
@@ -383,6 +387,7 @@ func (m *Api) GetViewsFromWorkspace(workspaceId string) ([]clickup.View, error) 
 	if err != nil {
 		return nil, err
 	}
+	views = filterViews(views, []clickup.ViewType{clickup.ViewTypeList})
 	m.logger.Debugf("Found %d views in workspace %s", len(views), workspaceId)
 
 	m.Cache.Set(cacheNamespace, workspaceId, views)
@@ -465,4 +470,15 @@ func (m *Api) InvalidateCache() error {
 		}
 	}
 	return nil
+}
+
+func filterViews(views []clickup.View, filters []clickup.ViewType) []clickup.View {
+	result := []clickup.View{}
+	for i := range views {
+		if slices.Contains(filters, views[i].Type) {
+			result = append(result, views[i])
+		}
+	}
+
+	return result
 }

--- a/pkg/clickup/clickup.go
+++ b/pkg/clickup/clickup.go
@@ -101,3 +101,28 @@ func (c *Client) parseQueryParams(p ...string) (string, error) {
 
 	return v.Encode(), nil
 }
+
+type RequestGet interface {
+	Error() string
+}
+
+func (c *Client) get(url string, objmap RequestGet) error {
+	errMsg := "Error occurs while getting resources from url: %s. Error: %s. Raw data: %s"
+	errApiMsg := errMsg + " API response: %s"
+
+	rawData, err := c.requestGet(url)
+	if err != nil {
+		return fmt.Errorf(errMsg, url, err, "none")
+	}
+
+	if err := json.Unmarshal(rawData, objmap); err != nil {
+		return fmt.Errorf(errApiMsg, url, err, string(rawData))
+	}
+
+	if objmap.Error() != "" {
+		return fmt.Errorf(
+			errMsg, url, "API response contains error.", string(rawData))
+	}
+
+	return nil
+}

--- a/pkg/clickup/folder.go
+++ b/pkg/clickup/folder.go
@@ -1,7 +1,5 @@
 package clickup
 
-import "encoding/json"
-
 type Folder struct {
 	Id               string        `json:"id"`
 	Name             string        `json:"name"`
@@ -21,17 +19,20 @@ type FolderSpace struct {
 
 type RequestGetFolders struct {
 	Folders []Folder `json:"folders"`
+	Err     string   `json:"err"`
+}
+
+func (r RequestGetFolders) Error() string {
+	return r.Err
 }
 
 func (c *Client) GetFolders(spaceId string) ([]Folder, error) {
-	rawData, err := c.requestGet("/space/" + spaceId + "/folder")
-	if err != nil {
-		return nil, err
-	}
+	return c.getFolders("/space/" + spaceId + "/folder")
+}
 
+func (c *Client) getFolders(url string) ([]Folder, error) {
 	var objmap RequestGetFolders
-
-	if err := json.Unmarshal(rawData, &objmap); err != nil {
+	if err := c.get(url, &objmap); err != nil {
 		return nil, err
 	}
 

--- a/pkg/clickup/list.go
+++ b/pkg/clickup/list.go
@@ -2,7 +2,6 @@ package clickup
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type ListFolder struct {
@@ -36,33 +35,33 @@ type List struct {
 }
 
 type RequestGetLists struct {
-	Err   string `json:"err"`
 	Lists []List `json:"lists"`
+	Err   string `json:"err"`
+}
+
+func (r RequestGetLists) Error() string {
+	return r.Err
 }
 
 func (c *Client) GetListsFromFolder(folderId string) ([]List, error) {
-	rawData, err := c.requestGet("/folder/" + folderId + "/list")
-	if err != nil {
-		return nil, err
-	}
+	return c.getLists("/folder/" + folderId + "/list")
+}
+
+func (c *Client) getLists(url string) ([]List, error) {
 	var objmap RequestGetLists
-
-	if err := json.Unmarshal(rawData, &objmap); err != nil {
+	if err := c.get(url, &objmap); err != nil {
 		return nil, err
 	}
-
-	if objmap.Err != "" {
-		return nil, fmt.Errorf(
-			"error occurs while getting lists from folders: %s. API response: %s",
-			folderId, string(rawData))
-	}
-
 	return objmap.Lists, nil
 }
 
 type RequestGetList struct {
-	Err  string `json:"err"`
 	List List   `json:"list"`
+	Err  string `json:"err"`
+}
+
+func (r RequestGetList) Error() string {
+	return r.Err
 }
 
 func (c *Client) GetList(listId string) (List, error) {

--- a/pkg/clickup/space.go
+++ b/pkg/clickup/space.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Space struct {
-	Id                string
+	Id                string        `json:"id"`
 	Name              string        `json:"name"`
 	Statuses          []SpaceStatus `json:"statuses"`
 	Features          []interface{} `json:"-"`

--- a/pkg/clickup/space.go
+++ b/pkg/clickup/space.go
@@ -1,10 +1,5 @@
 package clickup
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 type Space struct {
 	Id                string        `json:"id"`
 	Name              string        `json:"name"`
@@ -22,24 +17,22 @@ type SpaceStatus struct {
 }
 
 type RequestGetSpaces struct {
-	Err    string  `json:"err"`
 	Spaces []Space `json:"spaces"`
+	Err    string  `json:"err"`
 }
 
-func (c *Client) GetSpaces(teamId string) ([]Space, error) {
-	rawData, err := c.requestGet("/team/" + teamId + "/space")
-	if err != nil {
-		return nil, err
-	}
+func (r RequestGetSpaces) Error() string {
+	return r.Err
+}
 
+func (c *Client) GetSpacesFromTeam(teamId string) ([]Space, error) {
+	return c.getSpaces("/team/" + teamId + "/space")
+}
+
+func (c *Client) getSpaces(url string) ([]Space, error) {
 	var objmap RequestGetSpaces
-	if err := json.Unmarshal(rawData, &objmap); err != nil {
+	if err := c.get(url, &objmap); err != nil {
 		return nil, err
 	}
-
-	if objmap.Err != "" {
-		return nil, fmt.Errorf(objmap.Err)
-	}
-
 	return objmap.Spaces, nil
 }

--- a/pkg/clickup/task.go
+++ b/pkg/clickup/task.go
@@ -108,54 +108,30 @@ type Creator struct {
 }
 
 type RequestGetTasks struct {
-	Err      string `json:"err"`
 	Tasks    []Task `json:"tasks"`
 	LastPage bool   `json:"last_page"`
+	Err      string `json:"err"`
+}
+
+func (r RequestGetTasks) Error() string {
+	return r.Err
 }
 
 type RequestGetTask struct {
-	Err  string `json:"err"`
 	Task Task   `json:"task"`
+	Err  string `json:"err"`
+}
+
+func (r RequestGetTask) Error() string {
+	return r.Err
 }
 
 func (c *Client) GetTasksFromView(viewId string) ([]Task, error) {
-	rawData, err := c.requestGet("/view/" + viewId + "/task")
-	if err != nil {
-		return nil, err
-	}
-	var objmap RequestGetTasks
-
-	if err := json.Unmarshal(rawData, &objmap); err != nil {
-		return nil, err
-	}
-
-	if objmap.Err != "" {
-		return nil, fmt.Errorf(
-			"error occurs while getting tasks from view: %s. API response: %s",
-			viewId, string(rawData))
-	}
-
-	return objmap.Tasks, nil
+	return c.getTasks("/view/" + viewId + "/task")
 }
 
 func (c *Client) GetTasksFromList(listId string) ([]Task, error) {
-	rawData, err := c.requestGet("/list/" + listId + "/task")
-	if err != nil {
-		return nil, err
-	}
-	var objmap RequestGetTasks
-
-	if err := json.Unmarshal(rawData, &objmap); err != nil {
-		return nil, err
-	}
-
-	if objmap.Err != "" {
-		return nil, fmt.Errorf(
-			"error occurs while getting tasks from list: %s. API response: %s",
-			listId, string(rawData))
-	}
-
-	return objmap.Tasks, nil
+	return c.getTasks("/list/" + listId + "/task")
 }
 
 func (c *Client) GetTask(taskId string) (Task, error) {
@@ -170,4 +146,12 @@ func (c *Client) GetTask(taskId string) (Task, error) {
 	}
 
 	return objmap, nil
+}
+
+func (c *Client) getTasks(url string) ([]Task, error) {
+	var objmap RequestGetTasks
+	if err := c.get(url, &objmap); err != nil {
+		return nil, err
+	}
+	return objmap.Tasks, nil
 }

--- a/pkg/clickup/team.go
+++ b/pkg/clickup/team.go
@@ -5,10 +5,10 @@ import "encoding/json"
 type Workspace = Team
 
 type Team struct {
-	Id      string
-	Name    string
-	Color   string
-	Avatar  string
+	Id      string        `json:"id"`
+	Name    string        `json:"name"`
+	Color   string        `json:"color"`
+	Avatar  string        `json:"avatar"`
 	Members []interface{} `json:"members"`
 }
 

--- a/pkg/clickup/team.go
+++ b/pkg/clickup/team.go
@@ -1,7 +1,5 @@
 package clickup
 
-import "encoding/json"
-
 type Workspace = Team
 
 type Team struct {
@@ -14,18 +12,21 @@ type Team struct {
 
 type RequestGetTeams struct {
 	Teams []Team `json:"teams"`
+	Err   string `json:"err"`
+}
+
+func (r RequestGetTeams) Error() string {
+	return r.Err
 }
 
 func (c *Client) GetTeams() ([]Team, error) {
-	rawData, err := c.requestGet("/team")
-	if err != nil {
-		return nil, err
-	}
+	return c.getTeams("/team")
+}
 
+func (c *Client) getTeams(url string) ([]Team, error) {
 	var objmap RequestGetTeams
-	if err := json.Unmarshal(rawData, &objmap); err != nil {
+	if err := c.get(url, &objmap); err != nil {
 		return nil, err
 	}
-
 	return objmap.Teams, nil
 }


### PR DESCRIPTION
# Summary

A lot of time has flown by since I was doing anything inside the `clickup` pkg but today I saw there is a lot of code duplication that can be simplified.

- added `func (c *Client) get(url string, objmap RequestGet) error` and accepts 
  - `url string` for `c.requestGet(url)` to fetch data from Clickup API
  -  `objmap RequestGet` as an interface to which that data is loaded 
- added `type RequestGet interface` that only requires `Error() string)` method. Any RequestGet* struct must implement it 
- added `ViewType` type
- now pkg returns all views without any filtering. It is now api pkg's responsibility. It improves decoupling 