### PR TITLE
fix: proper handling ui error

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -57,7 +57,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case common.ErrMsg:
-		m.log.Fatal(msg.Error())
+		m.log.Error(msg.Error())
 		return m, tea.Quit
 
 	case tea.KeyMsg:
@@ -79,7 +79,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			"width", msg.Width,
 			"height", msg.Height)
 		m.ctx.WindowSize.Set(msg.Width, msg.Height)
-
 	}
 
 	m.viewCompact, cmd = m.viewCompact.Update(msg)


### PR DESCRIPTION
# Summary

While UI has been receiving `common.ErrMsg`, it triggered `log.Fatal`. That was causing improper program exiting (it was e.g. omitting main defer func)